### PR TITLE
feat: fully parse quantum report packet

### DIFF
--- a/src/radar/radar/receive/QuantumControls.py
+++ b/src/radar/radar/receive/QuantumControls.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, field
+import struct
+
+@dataclass(frozen=True, order=True)
+class QuantumControls:
+    gain_auto: int
+    gain: int
+    color_gain_auto: int
+    color_gain: int
+    sea_auto: int
+    sea: int
+    rain_auto: int
+    rain: int
+    
+    @staticmethod
+    def parse_controls(data: bytes):
+        fields = struct.unpack('<BBBBBBBB', data)
+        return fields

--- a/src/radar/radar/receive/QuantumReport.py
+++ b/src/radar/radar/receive/QuantumReport.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 import struct
+from radar.receive.QuantumControls import QuantumControls
+
 
 @dataclass(frozen=True, order=True)
 class QuantumReport:
@@ -26,7 +28,8 @@ class QuantumReport:
         fields = list(struct.unpack('<IB9sHBB2sBB32sBB3sB88s80s32s', data))
         fields[2] = struct.unpack('<9B', fields[2])
         fields[6] = struct.unpack('<2B', fields[6])
-        fields[9] = list(struct.unpack('<8s8s8s8s', fields[9]))
+        fields[9] = tuple(QuantumControls(*QuantumControls.parse_controls(d)) \
+                          for d in struct.unpack('<8s8s8s8s', fields[9]))
         fields[12] = struct.unpack('<3B', fields[12])
         fields[14] = struct.unpack('<88B', fields[14])
         fields[15] = struct.unpack('<20I', fields[15])

--- a/src/radar/radar/receive/QuantumScan.py
+++ b/src/radar/radar/receive/QuantumScan.py
@@ -16,7 +16,8 @@ class QuantumScan:
     
     @staticmethod
     def parse_header(data: bytes):
-        return struct.unpack('<IHHHHHHHH', data)
+        fields = struct.unpack('<IHHHHHHHH', data)
+        return fields
     
     @staticmethod
     def parse_data(data: bytes):
@@ -30,4 +31,4 @@ class QuantumScan:
                 unpacked_data.append(data[i])
                 i += 1
 
-        return unpacked_data
+        return tuple(unpacked_data)

--- a/src/radar/radar/receive/RMReport.py
+++ b/src/radar/radar/receive/RMReport.py
@@ -39,4 +39,5 @@ class RMReport:
     
     @staticmethod
     def parse_report(data: bytes):
-        return struct.unpack('<I44s132sB3sBB7sB2sB3sIB3sBB3sBB3sBB3sBHB3sB13sB', data)
+        fields = struct.unpack('<I44s132sB3sBB7sB2sB3sIB3sBB3sBB3sBB3sBHB3sB13sB', data)
+        return fields


### PR DESCRIPTION
Parses `controls` subfield inside the `quantum_report` packet that previously wasn't handled.

Before:
`QuantumReport(type=2621442, status=1, ..., mode=3, controls=[b'\x01A\x01(\x01\x03\x00\x00', b'\x01K\x012\x01\x00\x00\x00', b'\x01K\x012\x01\x00\x00\x00', b'\x00d\x002\x01\x00\x01\x00'], target_expansion=1, something_9=1, ...)`

After:
`QuantumReport(type=2621442, status=1, ..., mode=3, controls=(QuantumControls(gain_auto=1, gain=65, color_gain_auto=1, color_gain=40, sea_auto=1, sea=3, rain_auto=0, rain=0), QuantumControls(gain_auto=1, gain=75, color_gain_auto=1, color_gain=50, sea_auto=1, sea=0, rain_auto=0, rain=0), QuantumControls(gain_auto=1, gain=75, color_gain_auto=1, color_gain=50, sea_auto=1, sea=0, rain_auto=0, rain=0), QuantumControls(gain_auto=0, gain=100, color_gain_auto=0, color_gain=50, sea_auto=1, sea=0, rain_auto=1, rain=0)), target_expansion=1, something_9=1, ...)`